### PR TITLE
Use environment variable for Fontdeck ID.

### DIFF
--- a/views/_fontdeck.slim
+++ b/views/_fontdeck.slim
@@ -1,5 +1,5 @@
 javascript:
-  WebFontConfig = { fontdeck: { id: '36795' } };
+  WebFontConfig = { fontdeck: { id: '#{ENV['FONTDECK_ID']}' } };
 
   (function() {
     var wf = document.createElement('script');


### PR DESCRIPTION
When trying to deploy this app on Heroku and fontdeck attempts to load `FONTDECK_ID.js` it 
fails and breaks emberjs completely.  This pull request fixes that issue.

Note that in order to get this to work one needs to set `ENV['FONTDECK_ID']` which is provided by
fontdeck.com when one creates an account with them.

TODO: The instructions for deploying to Heroku need to be updated to include this new information.
