### PR TITLE
Added the ability to create a new milestone

### DIFF
--- a/assets/javascripts/board/controllers/milestone/create_controller.js
+++ b/assets/javascripts/board/controllers/milestone/create_controller.js
@@ -1,0 +1,24 @@
+var MilestonesCreateController = Ember.ObjectController.extend({
+  needs: ["application"],
+  actions: {
+    submit: function() {
+      var controller = this;
+      this.set("processing",true);
+      this.get("model").saveNew().then(function(milestone){
+         controller.send("milestoneCreated", milestone)
+         controller.set("processing",false)
+      });
+    }
+  },
+  isCollaboratorBinding: "App.repo.is_collaborator",
+  disabled: function () {
+      return this.get("processing") || !this.get("isValid");
+  }.property("processing","isValid"),
+  isValid: function () {
+    return this.get("model.title");
+  }.property("model.title")
+
+});
+
+module.exports = MilestonesCreateController;
+

--- a/assets/javascripts/board/controllers/milestones_controller.js
+++ b/assets/javascripts/board/controllers/milestones_controller.js
@@ -22,6 +22,6 @@ module.exports = MilestonesController = Ember.ObjectController.extend({
       });
     });
 
-  }.property(),
+  }.property("forceRedraw"),
   forceRedraw: 0
 });

--- a/assets/javascripts/board/models/milestone.js
+++ b/assets/javascripts/board/models/milestone.js
@@ -1,0 +1,30 @@
+var correlationId = require("../utilities/correlationId")
+var Serializable = require("../mixins/serializable");
+
+var Milestone = Ember.Object.extend(Serializable,{
+  correlationId: correlationId,
+  saveNew: function () {
+    return Ember.$.ajax( {
+      url: "/api/" + this.get("repo.full_name") + "/milestones",
+      data: JSON.stringify({milestone: this.serialize(), correlationId: this.get("correlationId") }),
+      dataType: 'json',
+      type: "POST",
+      contentType: "application/json"}).then(function(response){
+      return Milestone.create(response);
+    })
+  },
+  processing: false,
+  loaded: false
+});
+
+Milestone.reopenClass({
+  createNew: function(){
+     return Milestone.create({
+       id: null,
+       title: "",
+       repo: App.get("repo")
+     })
+  }
+});
+
+module.exports = Milestone;

--- a/assets/javascripts/board/routes/milestones_route.js
+++ b/assets/javascripts/board/routes/milestones_route.js
@@ -31,6 +31,10 @@ module.exports = MilestonesRoute =  Ember.Route.extend({
       this.controllerFor("issue.create").set("model", App.Issue.createNew());
       this.send("openModal","issue.create")
     },
+    createNewMilestone : function () {
+      this.controllerFor("milestone.create").set("model", App.Milestone.createNew());
+      this.send("openModal","milestone.create")
+    },
     archive: function (issue) {
       issue.archive();
     },
@@ -46,8 +50,17 @@ module.exports = MilestonesRoute =  Ember.Route.extend({
     },
     issueCreated: function(issue){
       var controller = this.controllerFor("milestones");
-      var issues = controller.get("model.issues")
+      var issues = controller.get("model.issues");
       issues.pushObject(issue);
+      Ember.run.schedule('afterRender', controller, function () {
+        controller.incrementProperty("forceRedraw");
+        this.send("closeModal")
+      }.bind(this))
+    },
+    milestoneCreated: function(milestone){
+      var controller = this.controllerFor("milestones");
+      var milestones = controller.get("model.milestones");
+      milestones.pushObject(milestone);
       Ember.run.schedule('afterRender', controller, function () {
         controller.incrementProperty("forceRedraw");
         this.send("closeModal")

--- a/assets/javascripts/board/templates/milestone/create.hbs
+++ b/assets/javascripts/board/templates/milestone/create.hbs
@@ -1,0 +1,12 @@
+<div class="fullscreen-card">
+  <form {{action "submit" on="submit"}} class="flex-form split-form">
+    <div class="flex-form-left">
+      <label>
+        {{input value=title placeholder="Title" }}
+      </label>
+      <button {{bind-attr disabled=disabled}} class="hb-button">Create milestone</button>
+    </div>
+    <div class="flex-form-right">
+    </div>
+  </form>
+</div>

--- a/assets/javascripts/board/templates/milestones.hbs
+++ b/assets/javascripts/board/templates/milestones.hbs
@@ -4,7 +4,8 @@
   </div>
  {{#if App.repo.is_collaborator}}
     <div class="create-button">
-      <button {{action createNewIssue }} class="hb-button small">Create new issue</button>
+      <button {{action "createNewIssue" }} class="hb-button small">Create new issue</button>
+      <button {{action "createNewMilestone" }} class="hb-button small">Create new milestone</button>
       <span class="dropdown">
         <a data-toggle="dropdown" class="dropdown-toggle hb-icon-link" href="#">
           <i class="ui-icon ui-icon-18 ui-icon-gear"></i>

--- a/assets/javascripts/board/views/milestone/create_view.js
+++ b/assets/javascripts/board/views/milestone/create_view.js
@@ -1,0 +1,4 @@
+var MilestonesCreateView = App.ModalView.extend({
+});
+
+module.exports = MilestonesCreateView;

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -151,7 +151,15 @@ class Huboard
       json pebble.reorder_milestone user, repo, number, index
     end
 
-    post '/:user/:repo/assigncard' do 
+    post '/:user/:repo/milestones' do
+      client_data = JSON.parse(request.body.read)
+       milestone = huboard.board(params[:user],params[:repo])
+          .create_milestone client_data
+
+       return json milestone
+    end
+
+    post '/:user/:repo/assigncard' do
       issue = pebble.assign_card params[:user], params[:repo], params[:number], params[:assignee]
 
       IssueAssignedEvent.new.publish issue, current_user.attribs, params[:correlationId]

--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -62,6 +62,14 @@ class Huboard
       milestone
     end
 
+    def create_milestone(params)
+       milestone = Hashie::Mash.new params["milestone"]
+
+       gh.milestones.create({
+         title: milestone.title
+       })
+    end
+
     module Card
 
       def current_state

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -32,6 +32,10 @@ module Stint
       gh.repos(user_name, repo).milestones number
     end
 
+    def milestones(user_name, repo)
+      gh.repos(user_name, repo).milestones
+    end
+
     def update_milestone(user_name, repo, milestone)
       gh.repos(user_name, repo).milestones(milestone[:number]).patch(milestone)
     end


### PR DESCRIPTION
This would resolve ticket #12

A new `Create new milestone` button has been added to the Milestones page. This will simply allow you to set the title of the new milestone and add it to the page.

For this pull request I decided to not include the changes to the `application.js` file. If you would like for me to add those changes, I can remove this PR and submit another one.

One thing I wanted to mention about the code is the placement of the `create_milestone` method in `lib/bridge/github/issues.rb`. I feel like it might be kind of weird to have it located in `issues.rb` so if you would rather have me create a `milestones.rb` and place it there, I can change it up.

<!---
@huboard:{"order":57.25,"milestone_order":371,"custom_state":""}
-->
