### PR TITLE
Scales account preseeding back

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,8 +27,6 @@ require 'app/helpers'
 require 'app/account_helpers'
 require 'app/routes'
 
-include HuBoard::AccountHelpers
-
 module HuBoard
   class EnsureEMRunning
     def initialize(app)

--- a/app/account_helpers.rb
+++ b/app/account_helpers.rb
@@ -1,12 +1,13 @@
 module HuBoard
   module AccountHelpers
+    extend self
 
     def trial_available?(customer)
-      customer[:trial] == "available"
+      customer == false || customer[:trial] == "available"
     end 
 
     def trial_active?(customer)
-      customer[:trial] == "active"
+      customer && customer[:trial] == "active"
     end
 
     def non_profit?(customer)
@@ -47,7 +48,7 @@ module HuBoard
         trial: "available"
       }
       couch.customers.save(customer_data)
-      return customer_data
+      return Hashie::Mash.new(customer_data)
     end
 
     def plan_for(user_or_org, customer)
@@ -63,6 +64,36 @@ module HuBoard
       plan[:purchased] = plan[:status] == "active" || trial_and_sub
       plan[:card] = customer.cards.data[0] rescue false
       plan
+    end
+
+    def default_org_mapping(org)
+      {
+        org: org.to_hash,
+        plans: [{
+          name: 'Organization',
+          id: 'org_basic_v1',
+          status: 'inactive',
+          amount: 2400
+        }],
+        trial: 'available',
+        has_plan: false,
+        non_profit: false
+      }
+    end
+
+    def default_user_mapping(user)
+      {
+        org: user.to_hash,
+        plans: [{
+          name: 'User',
+          id: 'user_basic_v1',
+          status: 'inactive',
+          amount: 700 
+        }],
+        trial: 'available',
+        has_plan: false,
+        non_profit: false
+      }
     end
   end
 end

--- a/app/assets/javascripts/accounts/application.js.erb
+++ b/app/assets/javascripts/accounts/application.js.erb
@@ -122,12 +122,6 @@ AccountController = Ember.ObjectController.extend({
     this.set("model.details.plans", Em.A(plans));
     return this.get("model.details.plans.firstObject");
   }.property("model.details.plans"),
-  activateTrial: function(){
-    var path = encodeURIComponent(window.location.pathname + window.location.hash);
-    var redirect = "?forward_to=" + path;
-    var user = this.get("model.login");
-    return "/settings/profile/" + user + "/trial/activate"  + redirect
-  }.property("model.login"),
   errorState: function(){
     return this.get("failure") || this.get("trialingExpired");
   }.property("failure", "trialingExpired"),
@@ -168,7 +162,25 @@ AccountController = Ember.ObjectController.extend({
   couponCode: function(){
     return this.get("model.details.discount.coupon.id");
   }.property("model.details.discount","model.details.discount.coupon", "model.details.discount.coupon.id"),
+  trialButtonDisabled: false,
+  trialActivationUrl: function(){
+    var path = encodeURIComponent(window.location.pathname + window.location.hash);
+    var redirect = "?forward_to=" + path;
+    var user = this.get("model.login");
+    return "/settings/profile/" + user + "/trial/activate"  + redirect
+  }.property("model.login"),
   actions: {
+    activateTrial: function(){
+      self = this
+      this.set("trialButtonDisabled", true)
+      Ember.$.ajax( {
+        url: self.get("trialActivationUrl"),
+        data: {billing_email: self.get("emailBinding")},
+        type: "POST"})
+        .then(function(response){
+          window.location.href = response.redirect;
+        });
+    },
     purchase: function (model) {
       var org = this.get("model.details.org");
       var details = this.get('model.details');
@@ -882,13 +894,28 @@ function program10(depth0,data) {
   data.buffer.push(escapeExpression(helpers['bind-attr'].call(depth0, {hash:{
     'class': ("noAccount:new-account:disabled")
   },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
-  data.buffer.push(">\n    <p>\n      <strong>All Accounts</strong> receive a <strong>15 day free trial</strong>.\n    </p>\n    <p>\n      <form ");
-  hashContexts = {'action': depth0};
-  hashTypes = {'action': "ID"};
+  data.buffer.push(">\n    <p>\n      <strong>All Accounts</strong> receive a <strong>15 day free trial</strong>.\n    </p>\n    <p>\n      <form>\n        ");
+  hashContexts = {'type': depth0,'placeholder': depth0,'name': depth0,'value': depth0,'required': depth0};
+  hashTypes = {'type': "STRING",'placeholder': "STRING",'name': "STRING",'value': "ID",'required': "STRING"};
+  options = {hash:{
+    'type': ("email"),
+    'placeholder': ("Email Address"),
+    'name': ("billing_email"),
+    'value': ("emailBinding"),
+    'required': ("required")
+  },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data};
+  data.buffer.push(escapeExpression(((stack1 = helpers.input || depth0.input),stack1 ? stack1.call(depth0, options) : helperMissing.call(depth0, "input", options))));
+  data.buffer.push("\n        <input class=\"hb-button\" type=\"submit\" value=\"Activate Trial\" ");
+  hashTypes = {};
+  hashContexts = {};
+  data.buffer.push(escapeExpression(helpers.action.call(depth0, "activateTrial", {hash:{},contexts:[depth0],types:["STRING"],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
+  data.buffer.push(" ");
+  hashContexts = {'disabled': depth0};
+  hashTypes = {'disabled': "STRING"};
   data.buffer.push(escapeExpression(helpers['bind-attr'].call(depth0, {hash:{
-    'action': ("activateTrial")
+    'disabled': ("trialButtonDisabled")
   },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
-  data.buffer.push(" method=\"post\">\n        <input type=\"email\" placeholder=\"Email Address\" name=\"billing_email\" required>\n        <input class=\"hb-button\" type=\"submit\" value=\"Activate Trial\"/>\n      </form>\n    </p>\n  </div>\n  <div ");
+  data.buffer.push(" />\n      </form>\n    </p>\n  </div>\n  <div ");
   hashContexts = {'class': depth0};
   hashTypes = {'class': "STRING"};
   data.buffer.push(escapeExpression(helpers['bind-attr'].call(depth0, {hash:{

--- a/app/assets/javascripts/accounts/application.js.erb
+++ b/app/assets/javascripts/accounts/application.js.erb
@@ -894,7 +894,13 @@ function program10(depth0,data) {
   data.buffer.push(escapeExpression(helpers['bind-attr'].call(depth0, {hash:{
     'class': ("noAccount:new-account:disabled")
   },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
-  data.buffer.push(">\n    <p>\n      <strong>All Accounts</strong> receive a <strong>15 day free trial</strong>.\n    </p>\n    <p>\n      <form>\n        ");
+  data.buffer.push(">\n    <p>\n      <strong>All Accounts</strong> receive a <strong>15 day free trial</strong>.\n    </p>\n    <p>\n      <form ");
+  hashContexts = {'on': depth0};
+  hashTypes = {'on': "STRING"};
+  data.buffer.push(escapeExpression(helpers.action.call(depth0, "activateTrial", {hash:{
+    'on': ("submit")
+  },contexts:[depth0],types:["STRING"],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
+  data.buffer.push(">\n        ");
   hashContexts = {'type': depth0,'placeholder': depth0,'name': depth0,'value': depth0,'required': depth0};
   hashTypes = {'type': "STRING",'placeholder': "STRING",'name': "STRING",'value': "ID",'required': "STRING"};
   options = {hash:{
@@ -905,17 +911,17 @@ function program10(depth0,data) {
     'required': ("required")
   },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data};
   data.buffer.push(escapeExpression(((stack1 = helpers.input || depth0.input),stack1 ? stack1.call(depth0, options) : helperMissing.call(depth0, "input", options))));
-  data.buffer.push("\n        <input class=\"hb-button\" type=\"submit\" value=\"Activate Trial\" ");
-  hashTypes = {};
-  hashContexts = {};
-  data.buffer.push(escapeExpression(helpers.action.call(depth0, "activateTrial", {hash:{},contexts:[depth0],types:["STRING"],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
-  data.buffer.push(" ");
-  hashContexts = {'disabled': depth0};
-  hashTypes = {'disabled': "STRING"};
-  data.buffer.push(escapeExpression(helpers['bind-attr'].call(depth0, {hash:{
+  data.buffer.push("\n        ");
+  hashContexts = {'class': depth0,'type': depth0,'value': depth0,'disabled': depth0};
+  hashTypes = {'class': "STRING",'type': "STRING",'value': "STRING",'disabled': "ID"};
+  options = {hash:{
+    'class': ("hb-button"),
+    'type': ("submit"),
+    'value': ("Activate Trial"),
     'disabled': ("trialButtonDisabled")
-  },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
-  data.buffer.push(" />\n      </form>\n    </p>\n  </div>\n  <div ");
+  },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data};
+  data.buffer.push(escapeExpression(((stack1 = helpers.input || depth0.input),stack1 ? stack1.call(depth0, options) : helperMissing.call(depth0, "input", options))));
+  data.buffer.push("\n      </form>\n    </p>\n  </div>\n  <div ");
   hashContexts = {'class': depth0};
   hashTypes = {'class': "STRING"};
   data.buffer.push(escapeExpression(helpers['bind-attr'].call(depth0, {hash:{

--- a/app/assets/javascripts/accounts/controllers/account_controller.js
+++ b/app/assets/javascripts/accounts/controllers/account_controller.js
@@ -5,12 +5,6 @@ AccountController = Ember.ObjectController.extend({
     this.set("model.details.plans", Em.A(plans));
     return this.get("model.details.plans.firstObject");
   }.property("model.details.plans"),
-  activateTrial: function(){
-    var path = encodeURIComponent(window.location.pathname + window.location.hash);
-    var redirect = "?forward_to=" + path;
-    var user = this.get("model.login");
-    return "/settings/profile/" + user + "/trial/activate"  + redirect
-  }.property("model.login"),
   errorState: function(){
     return this.get("failure") || this.get("trialingExpired");
   }.property("failure", "trialingExpired"),
@@ -51,7 +45,25 @@ AccountController = Ember.ObjectController.extend({
   couponCode: function(){
     return this.get("model.details.discount.coupon.id");
   }.property("model.details.discount","model.details.discount.coupon", "model.details.discount.coupon.id"),
+  trialButtonDisabled: false,
+  trialActivationUrl: function(){
+    var path = encodeURIComponent(window.location.pathname + window.location.hash);
+    var redirect = "?forward_to=" + path;
+    var user = this.get("model.login");
+    return "/settings/profile/" + user + "/trial/activate"  + redirect
+  }.property("model.login"),
   actions: {
+    activateTrial: function(){
+      self = this
+      this.set("trialButtonDisabled", true)
+      Ember.$.ajax( {
+        url: self.get("trialActivationUrl"),
+        data: {billing_email: self.get("emailBinding")},
+        type: "POST"})
+        .then(function(response){
+          window.location.href = response.redirect;
+        });
+    },
     purchase: function (model) {
       var org = this.get("model.details.org");
       var details = this.get('model.details');

--- a/app/assets/javascripts/accounts/templates/account.hbs
+++ b/app/assets/javascripts/accounts/templates/account.hbs
@@ -12,9 +12,9 @@
       <strong>All Accounts</strong> receive a <strong>15 day free trial</strong>.
     </p>
     <p>
-      <form>
+      <form {{action "activateTrial" on="submit"}}>
         {{input type="email" placeholder="Email Address" name="billing_email" value=emailBinding required="required"}}
-        <input class="hb-button" type="submit" value="Activate Trial" {{action "activateTrial"}} {{bind-attr disabled="trialButtonDisabled"}} />
+        {{input class="hb-button" type="submit" value="Activate Trial" disabled=trialButtonDisabled}}
       </form>
     </p>
   </div>

--- a/app/assets/javascripts/accounts/templates/account.hbs
+++ b/app/assets/javascripts/accounts/templates/account.hbs
@@ -12,9 +12,9 @@
       <strong>All Accounts</strong> receive a <strong>15 day free trial</strong>.
     </p>
     <p>
-      <form {{bind-attr action=activateTrial}} method="post">
-        <input type="email" placeholder="Email Address" name="billing_email" required>
-        <input class="hb-button" type="submit" value="Activate Trial"/>
+      <form>
+        {{input type="email" placeholder="Email Address" name="billing_email" value=emailBinding required="required"}}
+        <input class="hb-button" type="submit" value="Activate Trial" {{action "activateTrial"}} {{bind-attr disabled="trialButtonDisabled"}} />
       </form>
     </p>
   </div>

--- a/app/assets/stylesheets/_account.scss
+++ b/app/assets/stylesheets/_account.scss
@@ -26,9 +26,9 @@
       margin-top: -8px;
       margin-left: 6px;
     }
+    input[disabled] {
+      background-color: #7965cc;
+    }
   }
 }
 
-input[disabled] {
-  background-color: #7965cc;
-}

--- a/app/assets/stylesheets/_account.scss
+++ b/app/assets/stylesheets/_account.scss
@@ -28,3 +28,7 @@
     }
   }
 }
+
+input[disabled] {
+  background-color: #7965cc;
+}

--- a/app/routes/api/profiles.rb
+++ b/app/routes/api/profiles.rb
@@ -23,6 +23,8 @@ module HuBoard
 
           query = Queries::CouchCustomer.get(user["id"], couch)
           plan_doc = QueryHandler.exec(&query)
+          halt json({success: false, message: "Could Not Reach Couch"}) if plan_doc == false
+
           customer = account_exists?(plan_doc) ? plan_doc[:rows].first.value : false
           halt json(default_user_mapping(user)) unless customer
 
@@ -50,6 +52,8 @@ module HuBoard
 
           query = Queries::CouchCustomer.get(org["id"], couch)
           plan_doc = QueryHandler.exec(&query)
+          halt json({success: false, message: "Could Not Reach Couch"}) if plan_doc == false
+
           customer = account_exists?(plan_doc) ? plan_doc[:rows].first.value : false
           halt json(default_org_mapping(org)) unless customer
           

--- a/app/routes/api/webhooks.rb
+++ b/app/routes/api/webhooks.rb
@@ -42,7 +42,7 @@ module HuBoard
         #Thinking Ahead to API 2.0, all this logic should be encapsulated into an
         #event handler / background job
         post '/api/site/stripe/webhook' do
-          return json message: "Not Authorized" unless params[:token] == ENV["STRIPE_WEBHOOK_TOKEN"]
+          return json message: "Not Authorized" unless params[:stripe_token] == ENV["STRIPE_WEBHOOK_TOKEN"]
 
           payload = Hashie::Mash.new(params)
           id = payload.data.object.customer

--- a/app/routes/profiles.rb
+++ b/app/routes/profiles.rb
@@ -34,8 +34,8 @@ module HuBoard
 
       post '/settings/profile/:user/trial/activate' do
         user_or_org = gh.users(params[:user])
+        user_or_org["email"] = params[:billing_email]
         query = Queries::CouchCustomer.get(user_or_org["id"], couch)
-
         plan_doc = QueryHandler.exec(&query) 
         doc = account_exists?(plan_doc) ? plan_doc[:rows].first.value : create_new_account(gh.user, user_or_org)
 
@@ -56,7 +56,8 @@ module HuBoard
           couch.customers.save doc
         end
 
-        redirect (params[:forward_to] || session[:forward_to])
+        halt json(redirect: params[:forward_to]) if request.xhr?
+        redirect session[:forward_to]
       end
 
       get "/settings/profile/?" do

--- a/app/routes/profiles.rb
+++ b/app/routes/profiles.rb
@@ -1,6 +1,8 @@
 module HuBoard
   module Routes
     class Profiles < Base
+      include AccountHelpers
+
       set :stripe_key, ENV['STRIPE_API']
       set :stripe_publishable_key, ENV['STRIPE_PUBLISHABLE_API']
 
@@ -19,19 +21,25 @@ module HuBoard
 
       get "/settings/:user/trial" do
         @user = params[:user]
+        orgs = gh.user.memberships.orgs("active").body
+        not_admin = orgs.select!{|org| org["role"] == "admin"}.empty?
 
-        docs = couch.customers.findPlanById gh.users(@user)["id"]
-        trial = docs.rows.first.value.trial
+        query = Queries::CouchCustomer.get(gh.users(@user)["id"], couch)
+        plan_doc = QueryHandler.exec(&query)
+        customer = account_exists?(plan_doc) ? plan_doc[:rows].first.value : false
 
-        redirect session[:forward_to] if trial != "available"
+        redirect session[:forward_to] if !trial_available?(customer) || not_admin
         erb :activate_trial
       end
 
       post '/settings/profile/:user/trial/activate' do
-        docs = couch.customers.findPlanById gh.users(params[:user])["id"]
-        doc = docs.rows.first.value
+        user_or_org = gh.users(params[:user])
+        query = Queries::CouchCustomer.get(user_or_org["id"], couch)
 
-        if doc.trial == "available"
+        plan_doc = QueryHandler.exec(&query) 
+        doc = account_exists?(plan_doc) ? plan_doc[:rows].first.value : create_new_account(gh.user, user_or_org)
+
+        if doc && doc.trial == "available"
           customer = Stripe::Customer.retrieve(doc.id)
           account_type = doc.github.account.type == "User" ? "user_basic_v1" : "org_basic_v1"
           customer.subscriptions.create({

--- a/app/views/activate_trial.erb
+++ b/app/views/activate_trial.erb
@@ -11,3 +11,8 @@
     <a href="/"> No Thanks </a>
   </div>
 </div>
+<script type="text/javascript">
+  $("form").submit(function(){
+    $(this).find('input[type=submit]').attr('disabled', true);
+  });
+</script>

--- a/app/views/activate_trial.erb
+++ b/app/views/activate_trial.erb
@@ -12,7 +12,7 @@
   </div>
 </div>
 <script type="text/javascript">
-  $("form").submit(function(){
+  $("div.trial_form form").submit(function(){
     $(this).find('input[type=submit]').attr('disabled', true);
   });
 </script>

--- a/lib/use_cases/private_repo.rb
+++ b/lib/use_cases/private_repo.rb
@@ -1,5 +1,8 @@
+require "app/account_helpers"
+
 module UseCase
   class PrivateRepo
+    include HuBoard::AccountHelpers
     include SolidUseCase
 
     attr_accessor :couch, :gh
@@ -11,25 +14,19 @@ module UseCase
     steps :an_account_exists?, :a_trial_available?, :has_subscription?
 
     def an_account_exists?(params)
-      @repo_user ||= @gh.users(params[:user])
+      @repo_owner ||= @gh.users(params[:user])
 
-      customer_doc = QueryHandler.run do |q|
-        q << Queries::CouchCustomer.get(@repo_user["id"], @couch)
+      plan_doc = QueryHandler.run do |q|
+        q << Queries::CouchCustomer.get(@repo_owner["id"], @couch)
         q << Queries::PassThrough.go
       end
-      return fail(:pass_through) if customer_doc[:pass_through]
+      return fail(:pass_through) if plan_doc[:pass_through]
 
-      @customer = account_exists?(customer_doc) ? customer_doc[:rows].first.value : false
-      if !@customer && user_is_owner(params)
-        @customer = create_new_account(@gh.user, @repo_user)
-        continue(params)
-      else
-        continue(params)
-      end
+      @customer = account_exists?(plan_doc) ? plan_doc[:rows].first.value : false
+      continue(params)
     end
 
     def a_trial_available?(params)
-      return fail(:unauthorized) unless @customer
       if trial_available?(@customer) && user_is_owner(params)
         params[:trial_available] = true
         continue(params)
@@ -48,13 +45,13 @@ module UseCase
 
     :private
     def user_is_owner(params)
-      if @repo_user["type"] == "Organization"
-        @u ||= @gh.orgs(@repo_user["login"]).memberships(@gh.user["login"]) do |req|
+      if @repo_owner["type"] == "Organization"
+        @u ||= @gh.orgs(@repo_owner["login"]).memberships(@gh.user["login"]) do |req|
           req.headers["Accept"] = "application/vnd.github.moondragon+json"
         end
         return @u["role"] == "admin"
       end
-      @repo_user['login'] == @gh.user['login']
+      @repo_owner['login'] == @gh.user['login']
     end
   end
 end

--- a/spec/lib/webhooks/stripe/stripe_spec.rb
+++ b/spec/lib/webhooks/stripe/stripe_spec.rb
@@ -6,7 +6,7 @@ describe "Stripe Webhooks", :webhooks do
   let(:api_path) { "http://localhost:5000/api/site/stripe/webhook"}
   let(:stripe_token) { ENV["STRIPE_WEBHOOK_TOKEN"] }
 
-  let(:api) { "#{api_path}?token=#{stripe_token}" }
+  let(:api) { "#{api_path}?stripe_token=#{stripe_token}" }
   let(:content) { {"Content-Type" => "application/json"} }
 
   before(:each) do


### PR DESCRIPTION
- Only adds an account if a trial is activated, avoiding the creation of useless dummy accounts
- Prevents Duplicate trial requests
- Fixes trial activations bouncing if the user lacks a trial key