### PR TITLE
Show closed issues on all columns (not only last)

### DIFF
--- a/lib/bridge/github/board.rb
+++ b/lib/bridge/github/board.rb
@@ -56,7 +56,7 @@ class Huboard
       columns = column_labels
       first_column = columns.first
 
-      issues = issues().concat(closed_issues(columns.last['name'])).map do |i|
+      issues = issues().concat(closed_issues()).map do |i|
         i['current_state'] = first_column if i['current_state']['name'] == "__nil__"
         i['current_state'] = columns.find { |c| c['name'] == i['current_state']['name'] }
         i

--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -54,8 +54,9 @@ class Huboard
       result
     end
 
-    def closed_issues(label, since = (Time.now - 2*7*24*60*60).utc.iso8601)
+    def closed_issues(label = nil, since = (Time.now - 2*7*24*60*60).utc.iso8601)
       params = {labels: label, state: "closed", since: since, per_page: 30}
+      params.delete(:labels) if not params[:labels]
 
       gh.issues(params).each{|i| i.extend(Card)}.each{ |i|
         i.merge!(:repo => {owner: {login: user}, name: repo,  full_name: "#{user}/#{repo}" })


### PR DESCRIPTION
Using the board, some coders got confused when the issue got
automatic closed by github by merging on master, and then
it got ripped from the board.

Showing or not the closed could be better as an option
and not as a hardcoded behavior, but now is better than before :)